### PR TITLE
Tech WORK-75 | Error handling for Workflow Tasks

### DIFF
--- a/pkg/api/interface.go
+++ b/pkg/api/interface.go
@@ -44,9 +44,10 @@ type Operator struct {
 type Platform struct {
 	PlatformInterface
 
-	Options PrimalOptions
-	Fs      filesystem.FileSystem
-	Bundler *bundler.Bundler
+	Options  PrimalOptions
+	Fs       filesystem.FileSystem
+	Bundler  *bundler.Bundler
+	Workflow *workflow.Workflow
 }
 
 const (

--- a/pkg/operator/disk.go
+++ b/pkg/operator/disk.go
@@ -31,7 +31,11 @@ func (disk *Disk) Task() workflow.Task {
 			}
 
 			for key, file := range disk.Fs.Raw() {
-				f, _ := os.Create(path + key)
+				f, err := os.Create(path + key)
+				if err != nil {
+					self.ErrChan <- err
+				}
+
 				f.Write(file)
 			}
 

--- a/pkg/operator/disk_test.go
+++ b/pkg/operator/disk_test.go
@@ -48,7 +48,7 @@ func TestDisk_Task(t *testing.T) {
 		Root: root,
 	}).NewDisk()
 
-	testWorkflow := workflow.Workflow{}
+	testWorkflow := workflow.NewWorkflow()
 	testWorkflow.Add(diskOperator.Task())
 
 	tests := []struct {

--- a/pkg/operator/disk_test.go
+++ b/pkg/operator/disk_test.go
@@ -1,10 +1,13 @@
 package operator
 
 import (
+	"os"
+	"path"
 	"reflect"
 	"testing"
 
 	"inspr.dev/primal/pkg/api"
+	"inspr.dev/primal/pkg/workflow"
 )
 
 func TestNewDisk(t *testing.T) {
@@ -36,6 +39,49 @@ func TestNewDisk(t *testing.T) {
 	}
 }
 
-func (disk *Disk) TestTask(t *testing.T) {
-	
+func TestDisk_Task(t *testing.T) {
+	currDir, _ := os.Getwd()
+	root := path.Join(currDir, "../../")
+	buildFolder := path.Join(root, "__build__")
+
+	diskOperator := NewMockOperator(api.PrimalOptions{
+		Root: root,
+	}).NewDisk()
+
+	testWorkflow := workflow.Workflow{}
+	testWorkflow.Add(diskOperator.Task())
+
+	tests := []struct {
+		name        string
+		fileName    string
+		fileContent []byte
+		wantErr     bool
+	}{
+		{
+			name:        "write_file_to_disk",
+			fileName:    "/test.txt",
+			fileContent: []byte("test text"),
+			wantErr:     false,
+		},
+		{
+			name:        "failes_to_write_file_to_disk",
+			fileName:    "/no-folder/test.txt",
+			fileContent: []byte("test text"),
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		diskOperator.Fs.Write(tt.fileName, tt.fileContent)
+
+		testWorkflow.Run()
+
+		if _, err := os.Stat(buildFolder + tt.fileName); os.IsNotExist(err) {
+			if !tt.wantErr {
+				t.Errorf("Disk.TestTask() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		}
+	}
+
+	os.RemoveAll(buildFolder)
 }

--- a/pkg/operator/static.go
+++ b/pkg/operator/static.go
@@ -1,7 +1,6 @@
 package operator
 
 import (
-	"fmt"
 	"io/ioutil"
 	"path"
 
@@ -34,7 +33,7 @@ func (static *Static) Task() workflow.Task {
 
 				data, err := ioutil.ReadFile(fullPath)
 				if err != nil {
-					fmt.Println(err)
+					self.ErrChan <- err
 				}
 
 				filename := path.Base(relativePath)

--- a/pkg/platform/electron.go
+++ b/pkg/platform/electron.go
@@ -5,14 +5,11 @@ import (
 
 	"inspr.dev/primal/pkg/api"
 	"inspr.dev/primal/pkg/operator"
-	"inspr.dev/primal/pkg/workflow"
 )
 
 // Electron defines an electron platform data
 type Electron struct {
 	*Platform
-
-	workflow workflow.Workflow
 }
 
 // Electron returns an electron platform with it's tasks
@@ -22,7 +19,7 @@ func (p *Platform) Electron() api.PlatformInterface {
 	}
 
 	for _, ops := range operator.MainOps {
-		electron.workflow.Add(ops.Task())
+		electron.Platform.Workflow.Add(ops.Task())
 	}
 
 	return electron

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -7,6 +7,7 @@ import (
 	"inspr.dev/primal/pkg/bundler"
 	"inspr.dev/primal/pkg/filesystem"
 	"inspr.dev/primal/pkg/operator"
+	"inspr.dev/primal/pkg/workflow"
 )
 
 // Platform is created so it's possible to define methods
@@ -18,8 +19,9 @@ func NewPlatform(options api.PrimalOptions, fs filesystem.FileSystem) (api.Platf
 	operator.NewOperator(options, fs).InitMainOperators()
 
 	platform := &Platform{
-		Options: options,
-		Fs:      fs,
+		Workflow: workflow.NewWorkflow(),
+		Options:  options,
+		Fs:       fs,
 	}
 
 	switch options.Platform {

--- a/pkg/platform/web.go
+++ b/pkg/platform/web.go
@@ -3,14 +3,11 @@ package platform
 import (
 	"inspr.dev/primal/pkg/api"
 	"inspr.dev/primal/pkg/operator"
-	"inspr.dev/primal/pkg/workflow"
 )
 
 // Web defines a web platform data
 type Web struct {
 	*Platform
-
-	workflow workflow.Workflow
 }
 
 // Web returns a web platform with it's tasks
@@ -20,7 +17,7 @@ func (p *Platform) Web() api.PlatformInterface {
 	}
 
 	for _, ops := range operator.MainOps {
-		web.workflow.Add(ops.Task())
+		web.Platform.Workflow.Add(ops.Task())
 	}
 
 	return web
@@ -29,13 +26,13 @@ func (p *Platform) Web() api.PlatformInterface {
 // Run executes the workflow for the web platform
 func (w *Web) Run() {
 	w.Bundler.Target("client").Build()
-	w.workflow.Run()
+	w.Platform.Workflow.Run()
 }
 
 // Watch executes the workflow for the web platform in watch mode
 func (w *Web) Watch() {
 	w.Bundler.Target("client").Watch()
-	w.workflow.Run()
+	w.Platform.Workflow.Run()
 
 	server := Server{
 		reload: w.Bundler.Refresh(),

--- a/pkg/workflow/interface.go
+++ b/pkg/workflow/interface.go
@@ -1,5 +1,8 @@
 package workflow
 
+// ErrChan is a channel for passing errors from Tasks
+type ErrChan chan error
+
 // Status is an enum for possible Operators run status
 type Status int
 
@@ -27,9 +30,11 @@ type Task struct {
 	DependsOn []*Task
 
 	State Status
+	ErrChan
 }
 
 // Workflow is a set of tasks with a predefined order of execution
 type Workflow struct {
 	Tasks []*Task
+	ErrChan
 }

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -4,21 +4,21 @@ import (
 	"fmt"
 )
 
-var errChan chan error
-
-func init() {
-	errChan = make(chan error)
+// NewWorkflow return new Workflow struct
+func NewWorkflow() *Workflow {
+	return &Workflow{
+		ErrChan: make(chan error),
+	}
 }
 
 // Add adds a new task in a workflow
 func (w *Workflow) Add(task Task) {
-	task.ErrChan = errChan
+	task.ErrChan = w.ErrChan
 	w.Tasks = append(w.Tasks, &task)
 }
 
 // Run execs a workflow's tasks
 func (w *Workflow) Run() {
-	w.ErrChan = errChan
 Main:
 	for {
 		select {

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -4,32 +4,47 @@ import (
 	"fmt"
 )
 
+var errChan chan error
+
+func init() {
+	errChan = make(chan error)
+}
+
 // Add adds a new task in a workflow
 func (w *Workflow) Add(task Task) {
+	task.ErrChan = errChan
 	w.Tasks = append(w.Tasks, &task)
 }
 
 // Run execs a workflow's tasks
 func (w *Workflow) Run() {
+	w.ErrChan = errChan
+Main:
 	for {
-		if allTasksAreDone(w.Tasks) {
-			fmt.Println("Workflow is done")
+		select {
+		case err := <-w.ErrChan:
+			fmt.Println(err)
+			break Main
+		default:
+			if allTasksAreDone(w.Tasks) {
+				fmt.Println("Workflow is done")
+
+				for _, task := range w.Tasks {
+					task.State = IDLE
+				}
+				break Main
+			}
 
 			for _, task := range w.Tasks {
-				task.State = IDLE
-			}
-			break
-		}
+				if task.State != IDLE {
+					continue Main
+				}
 
-		for _, task := range w.Tasks {
-			if task.State != IDLE {
-				continue
-			}
-
-			// check if parents are done
-			if allTasksAreDone(task.DependsOn) {
-				task.State = RUNNING
-				go task.Run(task)
+				// check if parents are done
+				if allTasksAreDone(task.DependsOn) {
+					task.State = RUNNING
+					go task.Run(task)
+				}
 			}
 		}
 	}

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -37,7 +37,7 @@ Main:
 
 			for _, task := range w.Tasks {
 				if task.State != IDLE {
-					continue Main
+					continue
 				}
 
 				// check if parents are done

--- a/pkg/workflow/workflow_test.go
+++ b/pkg/workflow/workflow_test.go
@@ -82,42 +82,40 @@ func TestWorkflow_Run(t *testing.T) {
 // Auxiliar methods
 
 func generateMockWorkflow() *Workflow {
-	return &Workflow{
-		[]*Task{
+	w := &Workflow{}
+
+	w.Add(Task{
+		ID:    "task1",
+		State: DONE,
+	})
+	w.Add(Task{
+		ID:    "task2",
+		State: DONE,
+	})
+
+	return w
+}
+
+func mockWorkflowWithDependentTasks() *Workflow {
+	wf := Workflow{}
+
+	wf.Add(Task{
+		ID:    "task2",
+		State: RUNNING,
+	})
+	wf.Add(Task{
+		ID:    "task3",
+		State: IDLE,
+		DependsOn: []*Task{
 			{
 				ID:    "task1",
 				State: DONE,
 			},
-			{
-				ID:    "task2",
-				State: DONE,
-			},
 		},
-	}
-}
-
-func mockWorkflowWithDependentTasks() *Workflow {
-	wf := Workflow{
-		[]*Task{
-			{
-				ID:    "task2",
-				State: RUNNING,
-			},
-			{
-				ID:    "task3",
-				State: IDLE,
-				DependsOn: []*Task{
-					{
-						ID:    "task1",
-						State: DONE,
-					},
-				},
-				Run: func(self *Task) {
-					self.State = DONE
-				},
-			},
+		Run: func(self *Task) {
+			self.State = DONE
 		},
-	}
+	})
 
 	return &wf
 }


### PR DESCRIPTION
**Type**: Tech Pendency

**Section**: workflow operator

**Summary**:

Added Error channel for Workflow and Task, updated operators to use this channel. Updated tests for workflow and operators.

**Pay attention to**:
From now on we can add operators to workflow only trough workflow.Add() method, because in this method we apply ErrorChannel to Task. Creating workflow manually may cause an infinite loop and crash. 

```
// BAD - won't work
w := &Workflow{
    []*Task{
          {
              ID:    "task1",
              State: DONE,
          },
      },
  }
}
```
```
// GOOD - will work
  w := &Workflow{}
  
  w.Add(Task{
    ID:    "task1",
    State: DONE,
  })
```