### PR TITLE
Tech WORK-74 | PrimalOptions Root

### DIFF
--- a/cmd/primal/cli/build.go
+++ b/cmd/primal/cli/build.go
@@ -50,6 +50,8 @@ func runBuild(args []string) {
 		}
 
 		primal.Options = opts
+		inputPath = getDirPath(inputPath)
+		primal.Options.Root = inputPath
 		primal.Options.Watch = false
 
 		switch platformType {

--- a/cmd/primal/cli/build.go
+++ b/cmd/primal/cli/build.go
@@ -50,8 +50,7 @@ func runBuild(args []string) {
 		}
 
 		primal.Options = opts
-		inputPath = getDirPath(inputPath)
-		primal.Options.Root = inputPath
+		primal.Options.Root = getDirPath(inputPath)
 		primal.Options.Watch = false
 
 		switch platformType {

--- a/cmd/primal/cli/develop.go
+++ b/cmd/primal/cli/develop.go
@@ -50,9 +50,7 @@ func runDevelop(args []string) {
 		}
 
 		primal.Options = opts
-		inputPath = getDirPath(inputPath)
-		primal.Options.Root = inputPath
-		fmt.Println(primal.Options.Root)
+		primal.Options.Root = getDirPath(inputPath)
 		primal.Options.Watch = true
 
 		switch platformType {
@@ -75,5 +73,4 @@ func runDevelop(args []string) {
 		return
 	}
 	fmt.Print("yaml file not found for path ", inputPath, "\n")
-	fmt.Print(inputPath)
 }

--- a/cmd/primal/cli/develop.go
+++ b/cmd/primal/cli/develop.go
@@ -50,6 +50,9 @@ func runDevelop(args []string) {
 		}
 
 		primal.Options = opts
+		inputPath = getDirPath(inputPath)
+		primal.Options.Root = inputPath
+		fmt.Println(primal.Options.Root)
 		primal.Options.Watch = true
 
 		switch platformType {
@@ -72,4 +75,5 @@ func runDevelop(args []string) {
 		return
 	}
 	fmt.Print("yaml file not found for path ", inputPath, "\n")
+	fmt.Print(inputPath)
 }

--- a/cmd/primal/cli/utils.go
+++ b/cmd/primal/cli/utils.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 	"inspr.dev/primal/pkg/api"
@@ -42,4 +43,11 @@ func getConfigs(path string) (api.PrimalOptions, error) {
 	yaml.Unmarshal(bContent, &config)
 
 	return config, nil
+}
+
+func getDirPath(path string) string {
+	dir := strings.Split(path, "/")
+	dir = dir[:len(dir)-1]
+	newDir := strings.Join(dir, "/")
+	return newDir
 }

--- a/cmd/primal/cli/utils.go
+++ b/cmd/primal/cli/utils.go
@@ -48,6 +48,5 @@ func getConfigs(path string) (api.PrimalOptions, error) {
 func getDirPath(path string) string {
 	dir := strings.Split(path, "/")
 	dir = dir[:len(dir)-1]
-	newDir := strings.Join(dir, "/")
-	return newDir
+	return strings.Join(dir, "/")
 }


### PR DESCRIPTION
Type: Tech Pendency

Section: Cli

Summary:
-The root field in now inferred from the primal CLI command, and not from the user anymore.

Pay attention to:
The user still need to have a yaml file in the root folder, it can be empty.