### PR TITLE
Feat (platform | dev-server) | Create FileServer on top of http.FileServer

### DIFF
--- a/pkg/platform/dev-server.go
+++ b/pkg/platform/dev-server.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 	"time"
 
@@ -20,66 +19,16 @@ type Server struct {
 	reload (chan bool)
 }
 
-// ContentTypes defines the supported file content types
-var ContentTypes = map[string]string{
-	".css": "text/css; charset=UTF-8",
-
-	".js":  "application/javascript; charset=UTF-8",
-	".mjs": "application/javascript; charset=UTF-8",
-
-	".json":   "application/json; charset=UTF-8",
-	".jsonld": "application/ld+json; charset=UTF-8",
-
-	".png":  "image/png",
-	".webp": "image/webp",
-	".jpg":  "image/jpeg",
-	".jpeg": "image/jpeg",
-	".svg":  "image/svg+xml; charset=utf-8",
-
-	".woff":  "font/woff",
-	".woff2": "font/woff2",
-}
-
-// SetContentType adds the given file's content type to the header
-func SetContentType(w http.ResponseWriter, file string) {
-	ext := filepath.Ext(file)
-	w.Header().Add("Content-Type", ContentTypes[ext])
-}
-
-// SetCacheDuration adds Cache-Control header with the given amount of seconds
-func SetCacheDuration(w http.ResponseWriter, seconds int64) {
-	w.Header().Add("Cache-Control", fmt.Sprintf("max-age=%d", seconds))
-}
-
 // Start runs the dev server with the given filesystem in localhost:3049
 func (s *Server) Start(files filesystem.FileSystem) {
-	// WS handlers
+	// HotReload
 	go http.HandleFunc("/hmr", s.SendBundleUpdates)
 
-	go http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		var file []byte
-		var err error
-
-		path := r.URL.Path[0:]
-
-		switch path {
-		case "/":
-			file, err = files.Get("/index.html")
-		default:
-			file, err = files.Get(path)
-		}
-
-		if err == nil {
-			SetContentType(w, path)
-			// SetCacheDuration(w, 31536000)
-			w.Write(file)
-		} else {
-			w.WriteHeader(404)
-		}
-	})
+	// FileServer
+	fileServer := FileServer(http.Dir("__build__"), files)
+	go http.Handle("/", http.StripPrefix("/", fileServer))
 
 	fmt.Printf("Available on http://127.0.0.1:%d\n", 3049)
-
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", 3049), nil))
 }
 

--- a/pkg/platform/file-server.go
+++ b/pkg/platform/file-server.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"inspr.dev/primal/pkg/filesystem"

--- a/pkg/platform/file-server.go
+++ b/pkg/platform/file-server.go
@@ -16,7 +16,6 @@ type FileServerHandler = func(w http.ResponseWriter, r *http.Request) (goNext bo
 
 /*
 FileServer wraps the http.FileServer checking to see if the url path exists in it FileSystems(filesystem.FileSystem, http.FileSystem) first.
-If the file fails to exist it calls the inMemoryHandler function then onDiskHandler
 The implementation of Handlers can choose to either modify the request, e.g. change the URL path and return true to have the
 default FileServer handling to still take place, or return false to stop further processing, for example if you wanted
 to write a custom response
@@ -84,35 +83,4 @@ func inMemoryHandler(w http.ResponseWriter, r *http.Request, fs filesystem.FileS
 	w.Write(file)
 
 	return false
-}
-
-// ContentTypes defines the supported file content types
-var ContentTypes = map[string]string{
-	".css": "text/css; charset=UTF-8",
-
-	".js":  "application/javascript; charset=UTF-8",
-	".mjs": "application/javascript; charset=UTF-8",
-
-	".json":   "application/json; charset=UTF-8",
-	".jsonld": "application/ld+json; charset=UTF-8",
-
-	".png":  "image/png",
-	".webp": "image/webp",
-	".jpg":  "image/jpeg",
-	".jpeg": "image/jpeg",
-	".svg":  "image/svg+xml; charset=utf-8",
-
-	".woff":  "font/woff",
-	".woff2": "font/woff2",
-}
-
-// SetContentType adds the given file's content type to the header
-func SetContentType(w http.ResponseWriter, file string) {
-	ext := filepath.Ext(file)
-	w.Header().Add("Content-Type", ContentTypes[ext])
-}
-
-// SetCacheDuration adds Cache-Control header with the given amount of seconds
-func SetCacheDuration(w http.ResponseWriter, seconds int64) {
-	w.Header().Add("Cache-Control", fmt.Sprintf("max-age=%d", seconds))
 }

--- a/pkg/platform/file-server.go
+++ b/pkg/platform/file-server.go
@@ -59,7 +59,9 @@ func onDiskHandler(w http.ResponseWriter, r *http.Request, fs http.FileSystem, p
 	if err != nil {
 		if os.IsNotExist(err) {
 			// go next
-			fmt.Println("file doesn't exist on disk. shuting down", err)
+			w.WriteHeader(404)
+			fmt.Fprintf(w, "file doesn't exist on disk. %s", err.Error())
+
 			return false
 		}
 	}

--- a/pkg/platform/file-server.go
+++ b/pkg/platform/file-server.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FileServerHandler provides the function signature for passing to the FileServerWith404
-type FileServerHandler = func(w http.ResponseWriter, r *http.Request) (goNext bool)
+type FileServerHandler = func(w http.ResponseWriter, r *http.Request) bool
 
 /*
 FileServer wraps the http.FileServer checking to see if the url path exists in it FileSystems(filesystem.FileSystem, http.FileSystem) first.
@@ -54,12 +54,13 @@ func FileServer(root http.FileSystem, fs filesystem.FileSystem) http.Handler {
 	})
 }
 
-func onDiskHandler(w http.ResponseWriter, r *http.Request, fs http.FileSystem, path string) (goNext bool) {
+func onDiskHandler(w http.ResponseWriter, r *http.Request, fs http.FileSystem, path string) bool {
 	f, err := fs.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// go next
-			return true
+			fmt.Println("file doesn't exist on disk. shuting down", err)
+			return false
 		}
 	}
 
@@ -71,7 +72,7 @@ func onDiskHandler(w http.ResponseWriter, r *http.Request, fs http.FileSystem, p
 	return true
 }
 
-func inMemoryHandler(w http.ResponseWriter, r *http.Request, fs filesystem.FileSystem, path string) (goNext bool) {
+func inMemoryHandler(w http.ResponseWriter, r *http.Request, fs filesystem.FileSystem, path string) bool {
 	file, err := fs.Get(path)
 	if err != nil {
 		fmt.Println("err fs.get, should call next :", err)

--- a/pkg/platform/file-server.go
+++ b/pkg/platform/file-server.go
@@ -1,0 +1,118 @@
+package platform
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"inspr.dev/primal/pkg/filesystem"
+)
+
+// FileServerHandler provides the function signature for passing to the FileServerWith404
+type FileServerHandler = func(w http.ResponseWriter, r *http.Request) (goNext bool)
+
+/*
+FileServer wraps the http.FileServer checking to see if the url path exists in it FileSystems(filesystem.FileSystem, http.FileSystem) first.
+If the file fails to exist it calls the inMemoryHandler function then onDiskHandler
+The implementation of Handlers can choose to either modify the request, e.g. change the URL path and return true to have the
+default FileServer handling to still take place, or return false to stop further processing, for example if you wanted
+to write a custom response
+e.g. redirects to root and continues the file serving handler chain
+	func fileServerHandler404(w http.ResponseWriter, r *http.Request, ... ) (goNext bool) {
+		//if not found redirect to /
+		r.URL.Path = "/"
+		return true
+	}
+Use the same as you would with a http.FileServer e.g.
+	r.Handle("/", http.StripPrefix("/", FileServer(http.Dir("./staticDir"))))
+*/
+func FileServer(root http.FileSystem, fs filesystem.FileSystem) http.Handler {
+	fileServer := http.FileServer(root)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		//make sure the url path starts with /
+		upath := r.URL.Path
+		if !strings.HasPrefix(upath, "/") {
+			upath = "/" + upath
+			r.URL.Path = upath
+		}
+		upath = path.Clean(upath)
+
+		// attempt to open the file via the filesystem.FileSystem
+		if goNext := inMemoryHandler(w, r, fs, upath); !goNext {
+			return
+		}
+
+		// attempt to open the file via the http.FileSystem
+		if goNext := onDiskHandler(w, r, root, upath); !goNext {
+			return
+		}
+
+		// default serve
+		fileServer.ServeHTTP(w, r)
+	})
+}
+
+func onDiskHandler(w http.ResponseWriter, r *http.Request, fs http.FileSystem, path string) (goNext bool) {
+	f, err := fs.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// go next
+			return true
+		}
+	}
+
+	// close if successfully opened
+	if err == nil {
+		f.Close()
+	}
+
+	return true
+}
+
+func inMemoryHandler(w http.ResponseWriter, r *http.Request, fs filesystem.FileSystem, path string) (goNext bool) {
+	file, err := fs.Get(path)
+	if err != nil {
+		fmt.Println("err fs.get, should call next :", err)
+		return true
+	}
+
+	SetContentType(w, path)
+	w.Write(file)
+
+	return false
+}
+
+// ContentTypes defines the supported file content types
+var ContentTypes = map[string]string{
+	".css": "text/css; charset=UTF-8",
+
+	".js":  "application/javascript; charset=UTF-8",
+	".mjs": "application/javascript; charset=UTF-8",
+
+	".json":   "application/json; charset=UTF-8",
+	".jsonld": "application/ld+json; charset=UTF-8",
+
+	".png":  "image/png",
+	".webp": "image/webp",
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".svg":  "image/svg+xml; charset=utf-8",
+
+	".woff":  "font/woff",
+	".woff2": "font/woff2",
+}
+
+// SetContentType adds the given file's content type to the header
+func SetContentType(w http.ResponseWriter, file string) {
+	ext := filepath.Ext(file)
+	w.Header().Add("Content-Type", ContentTypes[ext])
+}
+
+// SetCacheDuration adds Cache-Control header with the given amount of seconds
+func SetCacheDuration(w http.ResponseWriter, seconds int64) {
+	w.Header().Add("Cache-Control", fmt.Sprintf("max-age=%d", seconds))
+}

--- a/template/index.tsx
+++ b/template/index.tsx
@@ -232,7 +232,7 @@ const Root = () => (
 )
 
 const WsUpdate = () => {
-    const conn = new WebSocket(`ws://${location.host}/ws`)
+    const conn = new WebSocket(`ws://${location.host}/hmr`)
 
     conn.addEventListener('close', (ev) => {
         console.log(


### PR DESCRIPTION
# Description

**Kind:**
Feature

**Section:**
pkg/platform/dev-server.go
newFile: pkg/platform/file-server.go

**Summary:**
This PR adds an FileServer based on golang default http.FileServer allowing us to call different handlers depending on use cases. The implementation of Handlers can choose to either modify the request, e.g. change the URL path and return true 
 or to have the default FileServer handling to still take place, or return false to stop further processing, for example if you wanted to write a custom response
 
## Changelog

added separate FileServer

## Pay attention to

> Important parts of the code that require special attention
